### PR TITLE
ELK Catalog entry

### DIFF
--- a/catalog/elk-stack.yaml
+++ b/catalog/elk-stack.yaml
@@ -37,10 +37,10 @@ chart-values:
 
 ---
 user-credentials:
-  kibana-uri: "http://{{ .Release.Name }}-kibana.{{ .Release.Namespace }}.{{ .Values.cluster.ingressDomain }}"
+  kibana-uri: "https://{{ .Release.Name }}-kibana.{{ .Release.Namespace }}.{{ .Values.cluster.ingressDomain }}"
   kibana-username: "{{ .Values.kibana.ingress.username }}"
   kibana-password: "{{ .Values.kibana.ingress.passwordPlain }}"
-  elasticsearch-uri: "http://{{ .Release.Name }}-es.{{ .Release.Namespace }}.{{ .Values.cluster.ingressDomain }}"
+  elasticsearch-uri: "https://{{ .Release.Name }}-es.{{ .Release.Namespace }}.{{ .Values.cluster.ingressDomain }}"
   elasticsearch-username: "{{ .Values.elasticsearch.ingress.username }}"
   elasticsearch-password: "{{ .Values.elasticsearch.ingress.passwordPlain }}"
 

--- a/catalog/elk-stack.yaml
+++ b/catalog/elk-stack.yaml
@@ -15,7 +15,7 @@ service:
 {{- $elasticsearchPassword := generatePassword -}}
 chart-values:
  cluster:
-   ingressDomain: {{ env "DOMAIN" }}
+   ingressDomain: {{ env "INGRESS_DOMAIN" }}
  kibana:
    ingress:
      enabled: true

--- a/catalog/elk-stack.yaml
+++ b/catalog/elk-stack.yaml
@@ -40,7 +40,7 @@ user-credentials:
   kibana-uri: "http://{{ .Release.Name }}-kibana.{{ .Release.Namespace }}.{{ .Values.cluster.ingressDomain }}"
   kibana-username: "{{ .Values.kibana.ingress.username }}"
   kibana-password: "{{ .Values.kibana.ingress.passwordPlain }}"
-  elasticsearch-uri: "http://{{ .Release.Name }}-elasticsearch.{{ .Release.Namespace }}.{{ .Values.cluster.ingressDomain }}"
+  elasticsearch-uri: "http://{{ .Release.Name }}-es.{{ .Release.Namespace }}.{{ .Values.cluster.ingressDomain }}"
   elasticsearch-username: "{{ .Values.elasticsearch.ingress.username }}"
   elasticsearch-password: "{{ .Values.elasticsearch.ingress.passwordPlain }}"
 

--- a/catalog/elk-stack.yaml
+++ b/catalog/elk-stack.yaml
@@ -1,0 +1,46 @@
+---
+service:
+  _id: 405e9529-f593-4f90-86e2-b0166a9e3a1e
+  _name: "elk-stack"
+  description: "ELK stack as a service"
+  chart: monostream/elk-stack
+  chart-version: 0.1.0
+  plans:
+  -
+    _id: 724d7a24-461c-4a46-9fe9-0c3243d99dce
+    _name: free
+    description: "Free ELK instance"
+---
+{{- $kibanaPassword := generatePassword -}}
+{{- $elasticsearchPassword := generatePassword -}}
+chart-values:
+ cluster:
+   ingressDomain: {{ env "DOMAIN" }}
+ kibana:
+   ingress:
+     enabled: true
+     usePassword: true
+     tls: true
+     username: "{{ generateUsername }}"
+     password: "{{ $kibanaPassword | htpasswd }}"
+     passwordPlain: "{{ $kibanaPassword }}"
+ elasticsearch:
+   ingress:
+     enabled: true
+     usePassword: true
+     tls: true
+     username: "{{ generateUsername }}"
+     password: "{{ $elasticsearchPassword | htpasswd }}"
+     passwordPlain: "{{ $elasticsearchPassword }}"
+ elasticsearch-curator:
+   enabled: true
+
+---
+user-credentials:
+  kibana-uri: "http://{{ .Release.Name }}-kibana.{{ .Release.Namespace }}.{{ .Values.cluster.ingressDomain }}"
+  kibana-username: "{{ .Values.kibana.ingress.username }}"
+  kibana-password: "{{ .Values.kibana.ingress.passwordPlain }}"
+  elasticsearch-uri: "http://{{ .Release.Name }}-elasticsearch.{{ .Release.Namespace }}.{{ .Values.cluster.ingressDomain }}"
+  elasticsearch-username: "{{ .Values.elasticsearch.ingress.username }}"
+  elasticsearch-password: "{{ .Values.elasticsearch.ingress.passwordPlain }}"
+

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -10,14 +10,14 @@ import (
 
 	"fmt"
 	"os"
-
 	"bytes"
 	"github.com/Masterminds/sprig"
 	"github.com/monostream/helmi/pkg/helm"
 	"github.com/monostream/helmi/pkg/kubectl"
 	"github.com/satori/go.uuid"
 	"strconv"
-	"golang.org/x/crypto/bcrypt"
+		"crypto/sha1"
+	"encoding/base64"
 )
 
 type Catalog struct {
@@ -155,12 +155,12 @@ func templateFuncMap() template.FuncMap {
 	}
 
 	f["htpasswd"] = func(str string) string {
+		s := sha1.New()
 
-		passwordBytes, err := bcrypt.GenerateFromPassword([]byte(str), bcrypt.MinCost)
-		if err != nil {
-			return ""
-		}
-		return string(passwordBytes)
+		s.Write([]byte(str))
+		passwordSum := []byte(s.Sum(nil))
+
+		return "{SHA}" + base64.StdEncoding.EncodeToString(passwordSum)
 	}
 
 	randomUuid := func() string {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -17,6 +17,7 @@ import (
 	"github.com/monostream/helmi/pkg/kubectl"
 	"github.com/satori/go.uuid"
 	"strconv"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type Catalog struct {
@@ -151,6 +152,15 @@ func templateFuncMap() template.FuncMap {
 			m["Error"] = err.Error()
 		}
 		return m
+	}
+
+	f["htpasswd"] = func(str string) string {
+
+		passwordBytes, err := bcrypt.GenerateFromPassword([]byte(str), bcrypt.MinCost)
+		if err != nil {
+			return ""
+		}
+		return string(passwordBytes)
 	}
 
 	randomUuid := func() string {


### PR DESCRIPTION
- Adds elk to the catalog
- Introduces a new template function (htpasswd) which allows to generate basic auths out of helmi used in the [chart](https://github.com/monostream/helm-charts/pull/9)

_Currently the environment variable for the domain is used to generate the ingress host._


