### PR TITLE
Service Health Checks

### DIFF
--- a/catalog/example-openiban.yaml
+++ b/catalog/example-openiban.yaml
@@ -26,3 +26,5 @@ chart-values:
 user-credentials:
   api: "http://{{ .Services.Address "openiban" .Values.service.port }}/"
   metrics: "http://{{ .Services.Address "openiban" .Values.service.port }}/metrics"
+health-checks:
+  - "http://{{ .Services.Address "openiban" .Values.service.port }}/metrics"

--- a/docs/Catalog Format.md
+++ b/docs/Catalog Format.md
@@ -52,4 +52,8 @@ user-credentials:
   port: "{{ .Services.Port "svcname" 8080 }}"
   username: "{{ .Values.username }}"
   password: "{{ .Values.password }}"
+# Optional list of URIs to which Helmi must connect successfully before a service is reported ready:
+#   Supported protocols: http, https, tcp, tls
+health-checks:
+  - "http://{{ .Services.Address "svcname" .Values.service.port }}"
 ```

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -162,12 +162,10 @@ func (b *Broker) Provision(ctx context.Context, instanceID string, details broke
 
 func (b *Broker) Deprovision(ctx context.Context, instanceID string, details brokerapi.DeprovisionDetails, asyncAllowed bool) (brokerapi.DeprovisionServiceSpec, error) {
 	spec := brokerapi.DeprovisionServiceSpec{}
-	exists, err := release.Exists(instanceID)
-	if err == nil && !exists {
+	err := release.Delete(instanceID)
+	if err == release.ReleaseNotFoundError {
 		return spec, brokerapi.ErrInstanceDoesNotExist
 	}
-
-	err = release.Delete(instanceID)
 	return spec, err
 }
 
@@ -176,9 +174,7 @@ func (b *Broker) Bind(ctx context.Context, instanceID, bindingID string, details
 	credentials, err := release.GetCredentials(&b.catalog, details.ServiceID, details.PlanID, instanceID)
 
 	if err != nil {
-		exists, existsErr := release.Exists(instanceID)
-
-		if existsErr == nil && !exists {
+		if err == release.ReleaseNotFoundError {
 			return binding, brokerapi.ErrInstanceDoesNotExist
 		}
 
@@ -206,8 +202,7 @@ func (b *Broker) LastOperation(ctx context.Context, instanceID, operationData st
 	status, err := release.GetStatus(instanceID)
 
 	if err != nil {
-		exists, existsErr := release.Exists(instanceID)
-		if existsErr == nil && !exists {
+		if err == release.ReleaseNotFoundError {
 			return op, brokerapi.ErrInstanceDoesNotExist
 		}
 

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -136,7 +136,7 @@ func Test_GetChartValues(t *testing.T) {
 	c := getCatalog(t)
 	s := c.Service("12345")
 	p := s.Plan("67890")
-	values, err := s.ChartValues(p)
+	values, err := s.ChartValues(p, "RELEASE-NAME", nil)
 	if err != nil {
 		t.Error(red(err.Error()))
 	}
@@ -148,6 +148,10 @@ func Test_GetChartValues(t *testing.T) {
 		"nested": map[string]interface{}{
 			"from_plan": "from plan",
 			"from_vals": "from vals",
+		},
+		metadataKey: map[string]interface{}{
+			metadataServiceIdKey: s.Id,
+			metadataPlanIdKey: p.Id,
 		},
 	}
 
@@ -161,12 +165,12 @@ func Test_GetUserCredentials(t *testing.T) {
 	s := c.Service("12345")
 	p := s.Plan("67890")
 
-	values, err := s.ChartValues(p)
+	values, err := s.ChartValues(p, "RELEASE-NAME", nil)
 	if err != nil {
 		t.Error(red(err.Error()))
 	}
 
-	credentials, err := s.UserCredentials(p, nodes, status, values)
+	release, err := s.ReleaseSection(p, nodes, status, values)
 	if err != nil {
 		t.Error(red(err.Error()))
 	}
@@ -190,6 +194,7 @@ func Test_GetUserCredentials(t *testing.T) {
 		},
 	}
 
+	credentials := release.UserCredentials
 	if !reflect.DeepEqual(expected, credentials) {
 		t.Error(red(fmt.Sprintf("expected %#v, got  %#v", expected, credentials)))
 	}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+var ReleaseNotFoundError = errors.New("release not found")
+
 type Status struct {
 	IsFailed    bool
 	IsDeployed  bool
@@ -122,7 +124,7 @@ func Delete(id string) error {
 				zap.String("id", id),
 				zap.String("name", name))
 
-			return nil
+			return ReleaseNotFoundError
 		}
 
 		logger.Error("failed to delete release",
@@ -154,7 +156,7 @@ func GetStatus(id string) (Status, error) {
 				zap.String("id", id),
 				zap.String("name", name))
 
-			return Status{}, err
+			return Status{}, ReleaseNotFoundError
 		}
 
 		logger.Error("failed to get release status",
@@ -192,7 +194,7 @@ func GetCredentials(catalog *catalog.Catalog, serviceId string, planId string, i
 				zap.String("id", id),
 				zap.String("name", name))
 
-			return nil, err
+			return nil, ReleaseNotFoundError
 		}
 
 		logger.Error("failed to get release status",


### PR DESCRIPTION
This adds an optional section in the catalog to have more in-depth readiness checks. Once Helm reports that all services are ready, Helmi will test these additional URLs before reporting the provision operation as completed. Example:

```yaml
user-credentials:
  api: "http://{{ .Services.Address "openiban" .Values.service.port }}/"
  metrics: "http://{{ .Services.Address "openiban" .Values.service.port }}/metrics"
health-checks:
  - "http://{{ .Services.Address "openiban" .Values.service.port }}/metrics"
```

Supported protocol schemas: 
 - `tcp` (tcp handshake must succeed)
 - `tls`(tls certificate must be valid (according to host root CAs) and tls handshake must succeed)
 - `http`(must return HTTP status <= 399)
 - `https` (see conditions from tls and http)
