### PR TITLE
Fix a small bug in release name deduction logic

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -326,8 +326,16 @@ func GetCredentials(catalog *catalog.Catalog, serviceId string, planId string, i
 	return release.UserCredentials, nil
 }
 
+func min(x int, y int) int {
+	if x > y {
+		return y
+	}
+	return x
+}
+
 func getName(value string) string {
 	const prefix = "helmi"
+	const maxLengthNoPrefix = 14
 
 	if strings.HasPrefix(value, prefix) {
 		return value
@@ -337,7 +345,7 @@ func getName(value string) string {
 	name = strings.Replace(name, "-", "", -1)
 	name = strings.Replace(name, "_", "", -1)
 
-	return prefix + name[:14]
+	return prefix + name[:min(maxLengthNoPrefix, len(name))]
 }
 
 func getChart(service *catalog.Service, plan *catalog.Plan) (string, error) {

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -34,6 +34,8 @@ func red(msg string) string {
 func Test_GetName(t *testing.T) {
 	const input string = "this_is-a_test_name_which-is_pretty-long"
 	const expected string = "helmithisisatestnam"
+	const inputShort string = "test1"
+	const expectedShort string = "helmitest1"
 
 	name := getName(input)
 
@@ -42,6 +44,15 @@ func Test_GetName(t *testing.T) {
 	}
 	if name != expected {
 		t.Error(red("name is wrong"))
+	}
+
+	nameShort := getName(inputShort)
+
+	if len(nameShort) != len(expectedShort) {
+		t.Error(red("length of nameShort is wrong"))
+	}
+	if nameShort != expectedShort {
+		t.Error(red("nameShort is wrong"))
 	}
 }
 


### PR DESCRIPTION
Fixes a bug where release would throw a panic if id of the release is too short. If id is prefixed with helmi, this does not happen but otherwise yes if id is less than 14 characters.