### PR TITLE
Allow context data to be used in chart values

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -397,6 +397,7 @@ type chartValueVars struct {
 	Service    *Service
 	Plan       *Plan
 	Parameters map[string]interface{}
+	Context    map[string]interface{}
 	Release    struct {
 		Name string
 	}
@@ -443,7 +444,7 @@ func ExtractMetadata(helmValues map[string]interface{}) (Metadata, error) {
 	return metadata, nil
 }
 
-func (s *Service) ChartValues(p *Plan, releaseName string, namespace kubectl.Namespace, params map[string]interface{}) (map[string]interface{}, error) {
+func (s *Service) ChartValues(p *Plan, releaseName string, namespace kubectl.Namespace, params map[string]interface{}, contextValues map[string]interface{}) (map[string]interface{}, error) {
 	b := new(bytes.Buffer)
 
 	// since Cluster.Address and Cluster.Hostname are never used in the ChartValues, errors here aren't handled
@@ -454,6 +455,7 @@ func (s *Service) ChartValues(p *Plan, releaseName string, namespace kubectl.Nam
 		Plan:       p,
 		Release:    struct{ Name string }{Name: releaseName},
 		Parameters: params,
+		Context: contextValues,
 		Cluster: &clusterVars{
 			Address:       extractAddress(nodes),
 			Hostname:      extractHostname(nodes),

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -49,7 +49,7 @@ func getLogger() *zap.Logger {
 	return logger
 }
 
-func Install(catalog *catalog.Catalog, serviceId string, planId string, id string, namespace kubectl.Namespace, acceptsIncomplete bool, parameters map[string]interface{}) error {
+func Install(catalog *catalog.Catalog, serviceId string, planId string, id string, namespace kubectl.Namespace, acceptsIncomplete bool, parameters map[string]interface{}, contextValues map[string]interface{}) error {
 	name := getName(id)
 	logger := getLogger()
 
@@ -58,7 +58,7 @@ func Install(catalog *catalog.Catalog, serviceId string, planId string, id strin
 
 	chart, chartErr := getChart(service, plan)
 	chartVersion, chartVersionErr := getChartVersion(service, plan)
-	chartValues, valuesErr := service.ChartValues(plan, name, namespace, parameters)
+	chartValues, valuesErr := service.ChartValues(plan, name, namespace, parameters, contextValues)
 
 	if chartErr != nil {
 		logger.Error("failed to read chart from catalog definition",


### PR DESCRIPTION
With this change you can use Context data in chart values: 

```
chart-values:
  postgresqlUsername: "{{ generateUsername }}"
  postgresqlPassword: "{{ generatePassword }}"
  postgresqlDatabase: db
  master:
    podLabels:
      environment: "{{ .Context.environment_id }}"
```